### PR TITLE
chore: fix type error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-defaults (2:1.22~3deepin2) unstable; urgency=medium
+
+  * Remove redundancy loong64 declaration in control file.
+
+ -- zhoushicheng <zhoushicheng@uniontech.com>  Mon, 18 Nov 2024 16:35:55 +0800
+
 golang-defaults (2:1.22~3deepin1) unstable; urgency=medium
 
   * add loong64.

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Vcs-Git: https://salsa.debian.org/go-team/compiler/golang-defaults.git
 Homepage: https://golang.org
 
 Package: golang-go
-Architecture: amd64 arm64 armel armhf i386 loong64 mips mips64el mipsel ppc64 ppc64el riscv64 s390x loong64
+Architecture: amd64 arm64 armel armhf i386 loong64 mips mips64el mipsel ppc64 ppc64el riscv64 s390x
 Multi-Arch: same
 Depends: golang-${golang:Version}-go,
          golang-src (>= ${source:Version}),


### PR DESCRIPTION
fixed typo in debian/control file. Rm redundancy loong64 arch declaration.

Log: typo fix loong64