### PR TITLE
chore: downgrade gccgo link

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-defaults (2:1.22~3deepin3) unstable; urgency=medium
+
+  * Downgrade gccgo-go link to gcc-12
+
+ -- zhoushicheng <zhoushicheng@uniontech.com>  Fri, 29 Nov 2024 10:02:32 +0800
+
 golang-defaults (2:1.22~3deepin2) unstable; urgency=medium
 
   * Remove redundancy loong64 declaration in control file.

--- a/debian/gccgo-go.links
+++ b/debian/gccgo-go.links
@@ -1,2 +1,2 @@
-usr/bin/go-14 usr/bin/go
-usr/bin/gofmt-14 usr/bin/gofmt
+usr/bin/go-12 usr/bin/go
+usr/bin/gofmt-12 usr/bin/gofmt


### PR DESCRIPTION
Downgrade gccgo-go.links from gcc14 to gcc12

Log: